### PR TITLE
Add Smart Document Q&A API with Gemini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/app/document_store.py
+++ b/app/document_store.py
@@ -1,0 +1,25 @@
+from typing import Dict, List
+from uuid import uuid4
+
+
+class DocumentStore:
+    """In-memory storage for uploaded documents."""
+
+    def __init__(self) -> None:
+        self._docs: Dict[str, Dict[str, str]] = {}
+
+    def add_document(self, text: str, filename: str) -> str:
+        doc_id = str(uuid4())
+        self._docs[doc_id] = {"filename": filename, "text": text}
+        return doc_id
+
+    def list_documents(self) -> List[Dict[str, str]]:
+        return [
+            {"id": doc_id, "filename": info["filename"]}
+            for doc_id, info in self._docs.items()
+        ]
+
+    def get_text(self, doc_id: str) -> str:
+        if doc_id not in self._docs:
+            raise KeyError(doc_id)
+        return self._docs[doc_id]["text"]

--- a/app/gemini_client.py
+++ b/app/gemini_client.py
@@ -1,0 +1,28 @@
+"""Wrapper around the Gemini API."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import google.generativeai as genai
+
+
+class GeminiClient:
+    def __init__(self, model: str = "gemini-2.5-flash", api_key: Optional[str] = None) -> None:
+        self.model_name = model
+        self.api_key = api_key or os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        self._model: Optional[genai.GenerativeModel] = None
+
+    def _ensure_model(self) -> None:
+        if self._model is None:
+            if not self.api_key:
+                raise RuntimeError("GEMINI_API_KEY environment variable is not set")
+            genai.configure(api_key=self.api_key)
+            self._model = genai.GenerativeModel(self.model_name)
+
+    def ask(self, text: str, question: str) -> str:
+        """Ask a question about a piece of text."""
+        self._ensure_model()
+        prompt = f"Document:\n{text}\n\nQuestion: {question}"
+        response = self._model.generate_content(prompt)
+        return response.text.strip()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,62 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException, Depends
+from pydantic import BaseModel
+import io
+from pypdf import PdfReader
+
+from .document_store import DocumentStore
+from .gemini_client import GeminiClient
+
+app = FastAPI()
+_store = DocumentStore()
+
+
+def get_store() -> DocumentStore:
+    return _store
+
+
+def get_gemini_client() -> GeminiClient:
+    return GeminiClient()
+
+
+class QuestionRequest(BaseModel):
+    question: str
+
+
+@app.post("/documents")
+async def upload_document(
+    file: UploadFile = File(...),
+    store: DocumentStore = Depends(get_store),
+):
+    if file.content_type not in {"application/pdf", "text/plain"}:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+    content = await file.read()
+    if file.content_type == "application/pdf":
+        try:
+            reader = PdfReader(io.BytesIO(content))
+            text = "\n".join(page.extract_text() or "" for page in reader.pages)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="Failed to process PDF") from exc
+    else:
+        text = content.decode("utf-8", errors="ignore")
+    doc_id = store.add_document(text, file.filename)
+    return {"id": doc_id}
+
+
+@app.get("/documents")
+def list_documents(store: DocumentStore = Depends(get_store)):
+    return {"documents": store.list_documents()}
+
+
+@app.post("/documents/{doc_id}/question")
+def ask_question(
+    doc_id: str,
+    request: QuestionRequest,
+    store: DocumentStore = Depends(get_store),
+    client: GeminiClient = Depends(get_gemini_client),
+):
+    try:
+        text = store.get_text(doc_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Document not found")
+    answer = client.ask(text, request.question)
+    return {"answer": answer}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pypdf
+google-generativeai
+python-multipart

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+
+from app.main import app, get_store, get_gemini_client
+from app.document_store import DocumentStore
+
+
+class FakeGeminiClient:
+    def ask(self, text: str, question: str) -> str:
+        assert text  # ensure document text passed
+        assert question
+        return "fake answer"
+
+
+def setup_test_app():
+    store = DocumentStore()
+    app.dependency_overrides[get_store] = lambda: store
+    app.dependency_overrides[get_gemini_client] = lambda: FakeGeminiClient()
+    return TestClient(app)
+
+
+def test_document_workflow():
+    client = setup_test_app()
+    # Upload a document
+    response = client.post(
+        "/documents",
+        files={"file": ("test.txt", b"hello world", "text/plain")},
+    )
+    assert response.status_code == 200
+    doc_id = response.json()["id"]
+
+    # List documents
+    response = client.get("/documents")
+    assert response.status_code == 200
+    docs = response.json()["documents"]
+    assert len(docs) == 1
+    assert docs[0]["id"] == doc_id
+
+    # Ask question
+    response = client.post(
+        f"/documents/{doc_id}/question",
+        json={"question": "What does the document say?"},
+    )
+    assert response.status_code == 200
+    assert response.json()["answer"] == "fake answer"


### PR DESCRIPTION
## Summary
- implement in-memory document store and FastAPI endpoints to upload and list documents
- wrap Gemini 2.5 Flash for answering document questions
- add tests for upload/list/question workflow and project requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb05d3bc548332865ab8d59a31e1d2