### PR TITLE
Implement Smart Document Q&A API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.env
+venv
+.venv
+.git
+.gitignore
+tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+venv/
+.venv/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Smart Document Q&A API
+
+This service lets you upload documents (PDF or text) and ask questions about their contents using the Gemini 2.5 Flash model.
+
+## Usage
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Provide your Gemini API key
+   ```bash
+   export GEMINI_API_KEY="your_key_here"
+   ```
+   You can also place this in a `.env` file.
+3. Start the server
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+## Endpoints
+- `POST /documents` – upload a PDF or text file
+- `GET /documents` – list uploaded documents
+- `POST /documents/{doc_id}/question` – ask a question about a document
+
+## Docker
+1. Build the image
+   ```bash
+   docker build -t smart-doc-qa .
+   ```
+2. Run the container
+   ```bash
+   docker run -p 8000:8000 -e GEMINI_API_KEY="your_key_here" smart-doc-qa
+   ```
+   The API will be available at `http://localhost:8000`.

--- a/app/document_store.py
+++ b/app/document_store.py
@@ -1,0 +1,25 @@
+from typing import Dict, List
+from uuid import uuid4
+
+
+class DocumentStore:
+    """In-memory storage for uploaded documents."""
+
+    def __init__(self) -> None:
+        self._docs: Dict[str, Dict[str, str]] = {}
+
+    def add_document(self, text: str, filename: str) -> str:
+        doc_id = str(uuid4())
+        self._docs[doc_id] = {"filename": filename, "text": text}
+        return doc_id
+
+    def list_documents(self) -> List[Dict[str, str]]:
+        return [
+            {"id": doc_id, "filename": info["filename"]}
+            for doc_id, info in self._docs.items()
+        ]
+
+    def get_text(self, doc_id: str) -> str:
+        if doc_id not in self._docs:
+            raise KeyError(doc_id)
+        return self._docs[doc_id]["text"]

--- a/app/gemini_client.py
+++ b/app/gemini_client.py
@@ -1,0 +1,30 @@
+"""Wrapper around the Gemini API."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from dotenv import load_dotenv
+import google.generativeai as genai
+
+
+class GeminiClient:
+    def __init__(self, model: str = "gemini-2.5-flash", api_key: Optional[str] = None) -> None:
+        self.model_name = model
+        load_dotenv()
+        self.api_key = api_key or os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+        self._model: Optional[genai.GenerativeModel] = None
+
+    def _ensure_model(self) -> None:
+        if self._model is None:
+            if not self.api_key:
+                raise RuntimeError("GEMINI_API_KEY environment variable is not set")
+            genai.configure(api_key=self.api_key)
+            self._model = genai.GenerativeModel(self.model_name)
+
+    def ask(self, text: str, question: str) -> str:
+        """Ask a question about a piece of text."""
+        self._ensure_model()
+        prompt = f"Document:\n{text}\n\nQuestion: {question}"
+        response = self._model.generate_content(prompt)
+        return response.text.strip()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,78 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException, Depends
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+import io
+from pypdf import PdfReader
+
+# Support running both as a package (e.g. ``uvicorn app.main:app``) and as a
+# standalone script (``python app/main.py``).  Relative imports work only when
+# the module is part of a package, so fall back to absolute imports if needed.
+try:  # pragma: no cover - trivial import glue
+    from .document_store import DocumentStore
+    from .gemini_client import GeminiClient
+except ImportError:  # executed when running as ``python app/main.py``
+    from document_store import DocumentStore
+    from gemini_client import GeminiClient
+
+app = FastAPI()
+
+
+@app.get("/", include_in_schema=False)
+async def root() -> RedirectResponse:
+    """Redirect the bare URL to the interactive API docs."""
+    return RedirectResponse("/docs")
+
+
+_store = DocumentStore()
+
+
+def get_store() -> DocumentStore:
+    return _store
+
+
+def get_gemini_client() -> GeminiClient:
+    return GeminiClient()
+
+
+class QuestionRequest(BaseModel):
+    question: str
+
+
+@app.post("/documents")
+async def upload_document(
+    file: UploadFile = File(...),
+    store: DocumentStore = Depends(get_store),
+):
+    if file.content_type not in {"application/pdf", "text/plain"}:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+    content = await file.read()
+    if file.content_type == "application/pdf":
+        try:
+            reader = PdfReader(io.BytesIO(content))
+            text = "\n".join(page.extract_text() or "" for page in reader.pages)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="Failed to process PDF") from exc
+    else:
+        text = content.decode("utf-8", errors="ignore")
+    doc_id = store.add_document(text, file.filename)
+    return {"id": doc_id}
+
+
+@app.get("/documents")
+def list_documents(store: DocumentStore = Depends(get_store)):
+    return {"documents": store.list_documents()}
+
+
+@app.post("/documents/{doc_id}/question")
+def ask_question(
+    doc_id: str,
+    request: QuestionRequest,
+    store: DocumentStore = Depends(get_store),
+    client: GeminiClient = Depends(get_gemini_client),
+):
+    try:
+        text = store.get_text(doc_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Document not found")
+    answer = client.ask(text, request.question)
+    return {"answer": answer}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+pypdf
+google-generativeai
+python-multipart
+python-dotenv
+httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+
+from app.main import app, get_store, get_gemini_client
+from app.document_store import DocumentStore
+
+
+class FakeGeminiClient:
+    def ask(self, text: str, question: str) -> str:
+        assert text  # ensure document text passed
+        assert question
+        return "fake answer"
+
+
+def setup_test_app():
+    store = DocumentStore()
+    app.dependency_overrides[get_store] = lambda: store
+    app.dependency_overrides[get_gemini_client] = lambda: FakeGeminiClient()
+    return TestClient(app)
+
+
+def test_document_workflow():
+    client = setup_test_app()
+    # Upload a document
+    response = client.post(
+        "/documents",
+        files={"file": ("test.txt", b"hello world", "text/plain")},
+    )
+    assert response.status_code == 200
+    doc_id = response.json()["id"]
+
+    # List documents
+    response = client.get("/documents")
+    assert response.status_code == 200
+    docs = response.json()["documents"]
+    assert len(docs) == 1
+    assert docs[0]["id"] == doc_id
+
+    # Ask question
+    response = client.post(
+        f"/documents/{doc_id}/question",
+        json={"question": "What does the document say?"},
+    )
+    assert response.status_code == 200
+    assert response.json()["answer"] == "fake answer"


### PR DESCRIPTION
## Summary
- Implement in-memory document storage for uploaded files
- Add Gemini client that loads API key from environment and queries Gemini 2.5 Flash
- Expose FastAPI endpoints to upload, list, and ask questions about documents
- Provide README with setup and usage instructions
- Containerize application with Dockerfile and .dockerignore for easier deployment
- Fix imports in main module so app can also run via `python app/main.py`
- Redirect the root URL to `/docs` so browsing to `http://localhost:8000/` no longer returns 404
- Ignore virtual environment and pytest cache directories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb05d3bc548332865ab8d59a31e1d2